### PR TITLE
Update runtime to 22.08

### DIFF
--- a/org.raspberrypi.rpi-imager.metainfo.xml
+++ b/org.raspberrypi.rpi-imager.metainfo.xml
@@ -56,7 +56,7 @@
     <binary>rpi-imager</binary>
   </provides>
   <releases>
-    <release version="1.7.3" date="2022-09-10"/>
+    <release version="1.7.3" date="2022-09-08"/>
     <release version="1.7.2" date="2022-03-30"/>
     <release version="1.7.1" date="2022-02-04"/>
     <release version="1.6.2" date="2021-10-07"/>

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -1,6 +1,6 @@
 app-id: org.raspberrypi.rpi-imager
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 command: rpi-imager
 rename-desktop-file: rpi-imager.desktop

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --socket=pulseaudio
   - --filesystem=xdg-download
   - --filesystem=/media
   - --filesystem=/run/media


### PR DESCRIPTION
Small PR to update the app to 1.7.3 and also update the runtime to 22.08 to ensure we are using the latest runtime.
This also adds the pulse audio flag which allows the play sound on finish option to work.