### PR TITLE
Use json checker, not anitya, to find releases

### DIFF
--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -34,9 +34,11 @@ modules:
         url: https://github.com/raspberrypi/rpi-imager/archive/refs/tags/v1.8.3.tar.gz
         sha256: dd603bff1c76c8a9d7156232397c8428a781b2ce25bb6e3cf9c63e7820f794c4
         x-checker-data:
-          type: anitya
-          project-id: 185260
-          stable-only: true
-          url-template: https://github.com/raspberrypi/rpi-imager/archive/refs/tags/v${version}.tar.gz
+          type: json
+          url: https://api.github.com/repos/raspberrypi/rpi-imager/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          timestamp-query: .published_at
+          url-query: |
+            "https://github.com/raspberrypi/rpi-imager/archive/refs/tags/v" + $version + ".tar.gz"
       - type: file
         path: org.raspberrypi.rpi-imager.metainfo.xml


### PR DESCRIPTION
This project does not actually publish tarballs, and the source being
used is the GitHub archive of the relevant tag. This is served without
any Last-Modified header and with Date set to the current day. This
means that the output of the checker is different every day, since a
different date is used in the metainfo file.

Instead, use the json checker to fetch the release from GitHub via its
API, which includes a timestamp.

Fixes https://github.com/flathub/flatpak-external-data-checker/issues/400
